### PR TITLE
feat: enable route persistence with optimistic UI and tests

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,68 +1,78 @@
-"use client"
+"use client";
 
-import { useState, useEffect } from "react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Badge } from "@/components/ui/badge"
-import { Users, Route, Music, Target, AlertCircle } from "lucide-react"
-import Link from "next/link"
-import { UserButton, SignedIn, SignedOut } from "@clerk/nextjs"
-import { getPreferences } from "@/lib/actions/preferences"
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
-import { Progress } from "@/components/ui/progress"
-import FieldView from "../components/field-view"
-import VisualCueLayer from "@/features/performance/VisualCueLayer"
-import SheetOverlay from "@/features/performance/SheetOverlay"
-import MusicPlayer from "../components/music-player"
-import Metronome from "../components/metronome"
-import RouteManager from "../components/route-manager"
-import RouteViewer from "@/features/routes/RouteViewer"
-import PracticeHUD from "@/features/practice/PracticeHUD"
-import MusicUpload from "@/features/practice/MusicUpload"
-import PhrasingSuggest from "@/features/practice/PhrasingSuggest"
-import StudentTracker from "../components/student-tracker"
-import { useGPSTracking } from "../hooks/use-gps-tracking"
-import { useAudioContext } from "../hooks/use-audio-context"
-import type { Student, MarchingRoute, Position } from "../types/marching-band"
-import type { AffineTransform } from "@/features/field/utils/fieldMath"
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { Users, Route, Music, Target, AlertCircle } from "lucide-react";
+import Link from "next/link";
+import { UserButton, SignedIn, SignedOut } from "@clerk/nextjs";
+import { getPreferences } from "@/lib/actions/preferences";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Progress } from "@/components/ui/progress";
+import FieldView from "../components/field-view";
+import VisualCueLayer from "@/features/performance/VisualCueLayer";
+import SheetOverlay from "@/features/performance/SheetOverlay";
+import MusicPlayer from "../components/music-player";
+import Metronome from "../components/metronome";
+import RouteManager from "../components/route-manager";
+import RouteViewer from "@/features/routes/RouteViewer";
+import RouteList from "@/features/routes/RouteList";
+import PracticeHUD from "@/features/practice/PracticeHUD";
+import MusicUpload from "@/features/practice/MusicUpload";
+import PhrasingSuggest from "@/features/practice/PhrasingSuggest";
+import StudentTracker from "../components/student-tracker";
+import { useGPSTracking } from "../hooks/use-gps-tracking";
+import { useAudioContext } from "../hooks/use-audio-context";
+import type { Student, MarchingRoute, Position } from "../types/marching-band";
+import type { AffineTransform } from "@/features/field/utils/fieldMath";
 
 export default function MarchingBandApp() {
-  const [students, setStudents] = useState<Student[]>([])
-  const [currentRoute, setCurrentRoute] = useState<MarchingRoute | null>(null)
-  const [isTracking, setIsTracking] = useState(false)
-  const [currentStudentId, setCurrentStudentId] = useState<string>("")
-  const [activeTab, setActiveTab] = useState("field")
-  const [isCalibrating, setIsCalibrating] = useState(false)
-  const [calibrationProgress, setCalibrationProgress] = useState(0)
-  const [calibrationSamples, setCalibrationSamples] = useState<number[]>([])
-  const [calibratedAccuracy, setCalibratedAccuracy] = useState<number | null>(null)
-  const [previewIndex, setPreviewIndex] = useState(0)
-  const [transform, setTransform] = useState<AffineTransform | null>(null)
-  const [bpm] = useState(120)
-  const [stepSizeYards, setStepSizeYards] = useState(0.75) // default ~27 inches
-  const [fieldType, setFieldType] = useState<"high-school" | "college">("high-school")
-  const [notationStyle, setNotationStyle] = useState<"yardline" | "steps-off">("yardline")
+  const [students, setStudents] = useState<Student[]>([]);
+  const [currentRoute, setCurrentRoute] = useState<MarchingRoute | null>(null);
+  const [isTracking, setIsTracking] = useState(false);
+  const [currentStudentId, setCurrentStudentId] = useState<string>("");
+  const [activeTab, setActiveTab] = useState("field");
+  const [isCalibrating, setIsCalibrating] = useState(false);
+  const [calibrationProgress, setCalibrationProgress] = useState(0);
+  const [calibrationSamples, setCalibrationSamples] = useState<number[]>([]);
+  const [calibratedAccuracy, setCalibratedAccuracy] = useState<number | null>(null);
+  const [previewIndex, setPreviewIndex] = useState(0);
+  const [transform, setTransform] = useState<AffineTransform | null>(null);
+  const [bpm] = useState(120);
+  const [stepSizeYards, setStepSizeYards] = useState(0.75); // default ~27 inches
+  const [fieldType, setFieldType] = useState<"high-school" | "college">("high-school");
+  const [notationStyle, setNotationStyle] = useState<"yardline" | "steps-off">("yardline");
 
   // Get GPS tracking data from the hook
-  const gpsTracking = useGPSTracking()
-  const { position, accuracy, isLocationEnabled, requestLocation, startTracking, stopTracking } = gpsTracking
+  const gpsTracking = useGPSTracking();
+  const { position, accuracy, isLocationEnabled, requestLocation, startTracking, stopTracking } =
+    gpsTracking;
 
-  const { audioContext, isAudioReady } = useAudioContext()
+  const { audioContext, isAudioReady } = useAudioContext();
 
   useEffect(() => {
     // Load user preferences if signed in; silently ignore errors
-    ;(async () => {
+    (async () => {
       try {
-        const pref = await getPreferences()
+        const pref = await getPreferences();
         if (pref) {
-          if (typeof pref.stepSizeYards === "number") setStepSizeYards(pref.stepSizeYards)
-          if (pref.fieldType === "high-school" || pref.fieldType === "college") setFieldType(pref.fieldType)
-          if (pref.notationStyle === "yardline" || pref.notationStyle === "steps-off") setNotationStyle(pref.notationStyle)
+          if (typeof pref.stepSizeYards === "number") setStepSizeYards(pref.stepSizeYards);
+          if (pref.fieldType === "high-school" || pref.fieldType === "college")
+            setFieldType(pref.fieldType);
+          if (pref.notationStyle === "yardline" || pref.notationStyle === "steps-off")
+            setNotationStyle(pref.notationStyle);
         }
       } catch {}
-    })()
-  }, [])
+    })();
+  }, []);
 
   useEffect(() => {
     // Initialize with sample student data
@@ -91,114 +101,117 @@ export default function MarchingBandApp() {
         position: { x: 70, y: 33, timestamp: Date.now() },
         isActive: true,
       },
-    ]
-    setStudents(sampleStudents)
-    setCurrentStudentId("1")
-  }, [])
+    ];
+    setStudents(sampleStudents);
+    setCurrentStudentId("1");
+  }, []);
 
   useEffect(() => {
     if (position && currentStudentId) {
-      const fieldPosition = convertGPSToFieldCoordinates(position)
+      const fieldPosition = convertGPSToFieldCoordinates(position);
       setStudents((prev) =>
-        prev.map((student) => (student.id === currentStudentId ? { ...student, position: fieldPosition } : student)),
-      )
+        prev.map((student) =>
+          student.id === currentStudentId ? { ...student, position: fieldPosition } : student,
+        ),
+      );
     }
-  }, [position, currentStudentId])
+  }, [position, currentStudentId]);
 
   useEffect(() => {
     // Handle calibration process
     if (isCalibrating && position && accuracy) {
       // Add current accuracy to samples
-      setCalibrationSamples((prev) => [...prev, accuracy])
+      setCalibrationSamples((prev) => [...prev, accuracy]);
 
       // Update progress
-      const progress = Math.min(100, (calibrationSamples.length / 10) * 100)
-      setCalibrationProgress(progress)
+      const progress = Math.min(100, (calibrationSamples.length / 10) * 100);
+      setCalibrationProgress(progress);
 
       // If we have enough samples, complete calibration
       if (calibrationSamples.length >= 10) {
         // Calculate average accuracy from samples
-        const avgAccuracy = calibrationSamples.reduce((sum, val) => sum + val, 0) / calibrationSamples.length
-        setCalibratedAccuracy(avgAccuracy)
-        setIsCalibrating(false)
+        const avgAccuracy =
+          calibrationSamples.reduce((sum, val) => sum + val, 0) / calibrationSamples.length;
+        setCalibratedAccuracy(avgAccuracy);
+        setIsCalibrating(false);
       }
     }
-  }, [isCalibrating, position, accuracy, calibrationSamples])
+  }, [isCalibrating, position, accuracy, calibrationSamples]);
 
   const convertGPSToFieldCoordinates = (gpsPos: GeolocationPosition): Position => {
-    const lat = gpsPos.coords.latitude
-    const lon = gpsPos.coords.longitude
-    let x: number
-    let y: number
+    const lat = gpsPos.coords.latitude;
+    const lon = gpsPos.coords.longitude;
+    let x: number;
+    let y: number;
     if (transform) {
       // Use calibrated affine transform
       const f = {
         x: transform.m[0] * lat + transform.m[1] * lon + transform.m[2],
         y: transform.m[3] * lat + transform.m[4] * lon + transform.m[5],
-      }
-      x = f.x
-      y = f.y
+      };
+      x = f.x;
+      y = f.y;
     } else {
       // Fallback naive mapping
-      x = (lon + 180) * (120 / 360)
-      y = (lat + 90) * (53.33 / 180)
+      x = (lon + 180) * (120 / 360);
+      y = (lat + 90) * (53.33 / 180);
     }
     return {
       x: Math.max(0, Math.min(120, x)),
       y: Math.max(0, Math.min(53.33, y)),
       timestamp: Date.now(),
-    }
-  }
+    };
+  };
 
   const handleStartTracking = async () => {
     if (!isLocationEnabled) {
-      await requestLocation()
+      await requestLocation();
     }
     // Start the GPS watcher/worker loop from the hook
-    startTracking()
-    setIsTracking(true)
-  }
+    startTracking();
+    setIsTracking(true);
+  };
 
   const handleStopTracking = () => {
     // Stop the GPS watcher/worker loop from the hook
-    stopTracking()
-    setIsTracking(false)
-  }
+    stopTracking();
+    setIsTracking(false);
+  };
 
   const startCalibration = async () => {
     if (!isLocationEnabled) {
-      await requestLocation()
+      await requestLocation();
     }
-    setCalibrationSamples([])
-    setCalibrationProgress(0)
-    setIsCalibrating(true)
-  }
+    setCalibrationSamples([]);
+    setCalibrationProgress(0);
+    setIsCalibrating(true);
+  };
 
   const cancelCalibration = () => {
-    setIsCalibrating(false)
-    setCalibrationSamples([])
-    setCalibrationProgress(0)
-  }
+    setIsCalibrating(false);
+    setCalibrationSamples([]);
+    setCalibrationProgress(0);
+  };
 
   const getAccuracyDescription = (accuracy: number | undefined | null) => {
-    if (accuracy === null || accuracy === undefined) return "Unknown"
-    if (accuracy < 3) return "High"
-    if (accuracy < 10) return "Medium"
-    return "Low"
-  }
+    if (accuracy === null || accuracy === undefined) return "Unknown";
+    if (accuracy < 3) return "High";
+    if (accuracy < 10) return "Medium";
+    return "Low";
+  };
 
   const getAccuracyColor = (accuracy: number | undefined | null) => {
-    if (accuracy === null || accuracy === undefined) return "text-gray-600"
-    if (accuracy < 3) return "text-green-600"
-    if (accuracy < 10) return "text-amber-600"
-    return "text-red-600"
-  }
+    if (accuracy === null || accuracy === undefined) return "text-gray-600";
+    if (accuracy < 3) return "text-green-600";
+    if (accuracy < 10) return "text-amber-600";
+    return "text-red-600";
+  };
 
   return (
     <div className="min-h-screen">
       <div className="container-app py-6 space-y-6">
         {/* Mobile Navigation */}
-  <div className="lg:hidden anchor-offset" id="field">
+        <div className="lg:hidden anchor-offset" id="field">
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
             <TabsList className="tabs-pills grid w-full grid-cols-4 h-12">
               <TabsTrigger value="field" className="flex flex-col gap-1 text-xs">
@@ -225,11 +238,21 @@ export default function MarchingBandApp() {
                   <CardTitle className="flex items-center justify-between text-lg">
                     Football Field
                     <div className="flex gap-2">
-                      <Button onClick={handleStartTracking} disabled={isTracking} size="sm" className="h-10 px-4">
+                      <Button
+                        onClick={handleStartTracking}
+                        disabled={isTracking}
+                        size="sm"
+                        className="h-10 px-4"
+                      >
                         {isTracking ? "Tracking" : "Start GPS"}
                       </Button>
                       {isTracking && (
-                        <Button onClick={handleStopTracking} variant="outline" size="sm" className="h-10 px-4">
+                        <Button
+                          onClick={handleStopTracking}
+                          variant="outline"
+                          size="sm"
+                          className="h-10 px-4"
+                        >
                           Stop
                         </Button>
                       )}
@@ -239,21 +262,27 @@ export default function MarchingBandApp() {
                 <CardContent>
                   <div className="relative">
                     <FieldView
-                    students={students}
-                    route={currentRoute}
-                    isTracking={isTracking}
-                    accuracy={accuracy || undefined}
-                    onRouteChange={setCurrentRoute}
-                    previewIndex={previewIndex}
-                    currentGeo={position ? { lat: position.coords.latitude, lon: position.coords.longitude } : null}
-                    currentFieldPos={students.find((s) => s.id === currentStudentId)?.position || null}
-                    stepSizeYards={stepSizeYards}
-                    fieldType={fieldType}
-                    notationStyle={notationStyle}
-                    onCalibrated={(t, rms) => {
-                      setTransform(t)
-                      // Optionally show feedback to user later using rms
-                    }}
+                      students={students}
+                      route={currentRoute}
+                      isTracking={isTracking}
+                      accuracy={accuracy || undefined}
+                      onRouteChange={setCurrentRoute}
+                      previewIndex={previewIndex}
+                      currentGeo={
+                        position
+                          ? { lat: position.coords.latitude, lon: position.coords.longitude }
+                          : null
+                      }
+                      currentFieldPos={
+                        students.find((s) => s.id === currentStudentId)?.position || null
+                      }
+                      stepSizeYards={stepSizeYards}
+                      fieldType={fieldType}
+                      notationStyle={notationStyle}
+                      onCalibrated={(t, rms) => {
+                        setTransform(t);
+                        // Optionally show feedback to user later using rms
+                      }}
                     />
                     {/* Performance overlays */}
                     <div className="absolute inset-0">
@@ -277,7 +306,11 @@ export default function MarchingBandApp() {
                     />
                   </div>
                   <div className="mt-4">
-                    <RouteViewer route={currentRoute} value={previewIndex} onChange={setPreviewIndex} />
+                    <RouteViewer
+                      route={currentRoute}
+                      value={previewIndex}
+                      onChange={setPreviewIndex}
+                    />
                   </div>
                 </CardContent>
               </Card>
@@ -292,6 +325,7 @@ export default function MarchingBandApp() {
 
             <TabsContent value="routes" className="mt-4 anchor-offset" id="routes">
               <div className="space-y-4">
+                <RouteList />
                 <RouteManager currentRoute={currentRoute} onRouteChange={setCurrentRoute} />
                 <RouteViewer route={currentRoute} value={previewIndex} onChange={setPreviewIndex} />
               </div>
@@ -314,7 +348,11 @@ export default function MarchingBandApp() {
           {accuracy && (
             <Card
               className={`border-l-4 ${
-                accuracy < 3 ? "border-l-green-500" : accuracy < 10 ? "border-l-amber-500" : "border-l-red-500"
+                accuracy < 3
+                  ? "border-l-green-500"
+                  : accuracy < 10
+                    ? "border-l-amber-500"
+                    : "border-l-red-500"
               } card-surface elevated`}
             >
               <CardContent className="p-4">
@@ -328,7 +366,10 @@ export default function MarchingBandApp() {
                   </Button>
                 </div>
                 <div className="mt-2 flex items-center gap-2">
-                  <Progress value={(1 - Math.min(accuracy, 20) / 20) * 100} className="h-2 flex-1" />
+                  <Progress
+                    value={(1 - Math.min(accuracy, 20) / 20) * 100}
+                    className="h-2 flex-1"
+                  />
                   <span className={`text-sm font-medium ${getAccuracyColor(accuracy)}`}>
                     {getAccuracyDescription(accuracy)} (±{accuracy.toFixed(1)}m)
                   </span>
@@ -339,7 +380,7 @@ export default function MarchingBandApp() {
         </div>
 
         {/* Desktop Layout */}
-  <div className="hidden lg:grid lg:grid-cols-3 gap-6" id="field-desktop">
+        <div className="hidden lg:grid lg:grid-cols-3 gap-6" id="field-desktop">
           {/* Main Field View */}
           <div className="lg:col-span-2">
             <Card className="card-surface elevated">
@@ -363,26 +404,38 @@ export default function MarchingBandApp() {
                   </div>
                 </CardTitle>
               </CardHeader>
-                <CardContent>
+              <CardContent>
                 <div className="relative">
-                <FieldView
-                  students={students}
-                  route={currentRoute}
-                  isTracking={isTracking}
-                  accuracy={accuracy || undefined}
-                  onRouteChange={setCurrentRoute}
-                  previewIndex={previewIndex}
-                  currentGeo={position ? { lat: position.coords.latitude, lon: position.coords.longitude } : null}
-                  currentFieldPos={students.find((s) => s.id === currentStudentId)?.position || null}
-                  stepSizeYards={stepSizeYards}
-                  fieldType={fieldType}
-                  notationStyle={notationStyle}
-                  onCalibrated={(t) => setTransform(t)}
-                />
-                <div className="absolute inset-0">
-                  <VisualCueLayer width={800} height={400} bpm={bpm} audioContext={audioContext} visible={true} />
-                  <SheetOverlay text={`Next: Step ${previewIndex + 1}`} visible={true} />
-                </div>
+                  <FieldView
+                    students={students}
+                    route={currentRoute}
+                    isTracking={isTracking}
+                    accuracy={accuracy || undefined}
+                    onRouteChange={setCurrentRoute}
+                    previewIndex={previewIndex}
+                    currentGeo={
+                      position
+                        ? { lat: position.coords.latitude, lon: position.coords.longitude }
+                        : null
+                    }
+                    currentFieldPos={
+                      students.find((s) => s.id === currentStudentId)?.position || null
+                    }
+                    stepSizeYards={stepSizeYards}
+                    fieldType={fieldType}
+                    notationStyle={notationStyle}
+                    onCalibrated={(t) => setTransform(t)}
+                  />
+                  <div className="absolute inset-0">
+                    <VisualCueLayer
+                      width={800}
+                      height={400}
+                      bpm={bpm}
+                      audioContext={audioContext}
+                      visible={true}
+                    />
+                    <SheetOverlay text={`Next: Step ${previewIndex + 1}`} visible={true} />
+                  </div>
                 </div>
                 <div className="mt-4">
                   <PracticeHUD
@@ -394,7 +447,11 @@ export default function MarchingBandApp() {
                   />
                 </div>
                 <div className="mt-4">
-                  <RouteViewer route={currentRoute} value={previewIndex} onChange={setPreviewIndex} />
+                  <RouteViewer
+                    route={currentRoute}
+                    value={previewIndex}
+                    onChange={setPreviewIndex}
+                  />
                 </div>
               </CardContent>
             </Card>
@@ -425,7 +482,11 @@ export default function MarchingBandApp() {
               <TabsContent value="routes" className="mt-4">
                 <div className="space-y-4">
                   <RouteManager currentRoute={currentRoute} onRouteChange={setCurrentRoute} />
-                  <RouteViewer route={currentRoute} value={previewIndex} onChange={setPreviewIndex} />
+                  <RouteViewer
+                    route={currentRoute}
+                    value={previewIndex}
+                    onChange={setPreviewIndex}
+                  />
                 </div>
               </TabsContent>
 
@@ -464,7 +525,9 @@ export default function MarchingBandApp() {
                     transition: "transform 0.5s ease",
                   }}
                 ></div>
-                <div className="text-2xl font-bold text-blue-700">{Math.round(calibrationProgress)}%</div>
+                <div className="text-2xl font-bold text-blue-700">
+                  {Math.round(calibrationProgress)}%
+                </div>
               </div>
             </div>
 
@@ -485,7 +548,9 @@ export default function MarchingBandApp() {
                 <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
                   <div>
                     <span className="text-gray-600">Accuracy:</span>
-                    <div className={`font-medium ${getAccuracyColor(accuracy)}`}>±{accuracy.toFixed(1)}m</div>
+                    <div className={`font-medium ${getAccuracyColor(accuracy)}`}>
+                      ±{accuracy.toFixed(1)}m
+                    </div>
                   </div>
                   <div>
                     <span className="text-gray-600">Quality:</span>
@@ -516,7 +581,9 @@ export default function MarchingBandApp() {
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>GPS Calibration Complete</DialogTitle>
-            <DialogDescription>We&apos;ve analyzed your GPS signal quality based on multiple samples.</DialogDescription>
+            <DialogDescription>
+              We&apos;ve analyzed your GPS signal quality based on multiple samples.
+            </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-6 py-4">
@@ -541,18 +608,18 @@ export default function MarchingBandApp() {
               <h4 className="font-medium">What this means:</h4>
               {calibratedAccuracy && calibratedAccuracy < 3 ? (
                 <p className="text-sm text-gray-600">
-                  Your GPS accuracy is excellent! You can expect precise position tracking suitable for
-                  competition-level marching.
+                  Your GPS accuracy is excellent! You can expect precise position tracking suitable
+                  for competition-level marching.
                 </p>
               ) : calibratedAccuracy && calibratedAccuracy < 10 ? (
                 <p className="text-sm text-gray-600">
-                  Your GPS accuracy is acceptable for practice sessions. For better precision, try moving to a more open
-                  area.
+                  Your GPS accuracy is acceptable for practice sessions. For better precision, try
+                  moving to a more open area.
                 </p>
               ) : (
                 <p className="text-sm text-gray-600">
-                  Your GPS accuracy is limited. Consider moving to an open area away from buildings or using an external
-                  GPS receiver for better results.
+                  Your GPS accuracy is limited. Consider moving to an open area away from buildings
+                  or using an external GPS receiver for better results.
                 </p>
               )}
             </div>
@@ -560,9 +627,9 @@ export default function MarchingBandApp() {
             <div className="bg-blue-50 p-4 rounded-lg">
               <h4 className="font-medium text-blue-900 mb-2">Field Position Impact</h4>
               <p className="text-sm text-blue-800">
-                With your current GPS accuracy of ±{calibratedAccuracy?.toFixed(1) || "?"}m, expect field positions to
-                be accurate within approximately ±{calibratedAccuracy ? (calibratedAccuracy * 1.09361).toFixed(1) : "?"}{" "}
-                yards.
+                With your current GPS accuracy of ±{calibratedAccuracy?.toFixed(1) || "?"}m, expect
+                field positions to be accurate within approximately ±
+                {calibratedAccuracy ? (calibratedAccuracy * 1.09361).toFixed(1) : "?"} yards.
               </p>
             </div>
           </div>
@@ -573,5 +640,5 @@ export default function MarchingBandApp() {
         </DialogContent>
       </Dialog>
     </div>
-  )
+  );
 }

--- a/features/routes/RouteList.tsx
+++ b/features/routes/RouteList.tsx
@@ -66,9 +66,10 @@ export default function RouteList() {
         setRoutes((prev) => prev.filter((r) => r.id !== id));
       } catch {
         // refetch on error
-        const refreshed = await fetchRoutes();
-        setRoutes(refreshed);
-      }
+        if (typeof fetchRoutes === "function") {
+          const refreshed = await fetchRoutes();
+          setRoutes(refreshed);
+        } // else, do nothing (fetchRoutes not defined)
     });
   }
 

--- a/features/routes/RouteList.tsx
+++ b/features/routes/RouteList.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, useEffect, useOptimistic, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import type { MarchingRoute } from "@/schemas/routeSchema";
+import { createRoute, deleteRoute } from "@/lib/actions/routes";
+import { fetchRoutes } from "@/lib/fetchers/routes";
+
+export default function RouteList() {
+  const [routes, setRoutes] = useState<MarchingRoute[]>([]);
+  const [optimisticRoutes, setOptimisticRoutes] = useOptimistic(
+    routes,
+    (state, action: { type: "add"; route: MarchingRoute } | { type: "remove"; id: string }) => {
+      switch (action.type) {
+        case "add":
+          return [...state, action.route];
+        case "remove":
+          return state.filter((r) => r.id !== action.id);
+      }
+    },
+  );
+  const [isPending, startTransition] = useTransition();
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const initial = await fetchRoutes();
+        setRoutes(initial);
+      } catch {
+        // ignore fetch errors
+      }
+    })();
+  }, []);
+
+  async function handleAdd() {
+    if (!name.trim()) return;
+    const route: MarchingRoute = {
+      id: crypto.randomUUID(),
+      name,
+      description: "",
+      waypoints: [],
+      duration: 0,
+      formations: [],
+    };
+    startTransition(async () => {
+      setOptimisticRoutes({ type: "add", route });
+      setName("");
+      try {
+        const saved = await createRoute(route);
+        setRoutes((prev) => [...prev, saved]);
+      } catch {
+        // revert on error
+        setRoutes((prev) => prev);
+      }
+    });
+  }
+
+  async function handleDelete(id: string) {
+    startTransition(async () => {
+      setOptimisticRoutes({ type: "remove", id });
+      try {
+        await deleteRoute(id);
+        setRoutes((prev) => prev.filter((r) => r.id !== id));
+      } catch {
+        // refetch on error
+        const refreshed = await fetchRoutes();
+        setRoutes(refreshed);
+      }
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Saved Routes</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex gap-2">
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Route name"
+            className="flex-1"
+          />
+          <Button onClick={handleAdd} disabled={isPending} className="shrink-0">
+            Add
+          </Button>
+        </div>
+        <ul className="space-y-2">
+          {optimisticRoutes.map((r) => (
+            <li key={r.id} className="flex items-center justify-between">
+              <span className="text-sm">{r.name}</span>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => handleDelete(r.id)}
+                disabled={isPending}
+              >
+                Delete
+              </Button>
+            </li>
+          ))}
+          {optimisticRoutes.length === 0 && (
+            <li className="text-sm text-muted-foreground">No routes saved</li>
+          )}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/actions/routes.test.ts
+++ b/lib/actions/routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import type { MarchingRoute } from "../../schemas/routeSchema";
+import type { MarchingRoute } from "@/schemas/routeSchema";
 import { createRoute, listRoutes, deleteRoute } from "./routes";
 
 const baseRoute = (): MarchingRoute => ({

--- a/lib/actions/routes.test.ts
+++ b/lib/actions/routes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { MarchingRoute } from "../../schemas/routeSchema";
+import { createRoute, listRoutes, deleteRoute } from "./routes";
+
+const baseRoute = (): MarchingRoute => ({
+  id: crypto.randomUUID(),
+  name: "Test Route",
+  description: "",
+  duration: 0,
+  formations: [],
+  waypoints: [],
+});
+
+describe("route actions (in-memory)", () => {
+  beforeEach(async () => {
+    const routes = await listRoutes();
+    for (const r of routes) {
+      await deleteRoute(r.id);
+    }
+  });
+
+  it("creates and lists routes", async () => {
+    const route = baseRoute();
+    await createRoute(route);
+    const routes = await listRoutes();
+    expect(routes).toHaveLength(1);
+    expect(routes[0]).toMatchObject({ id: route.id, name: route.name });
+  });
+
+  it("deletes routes", async () => {
+    const route = baseRoute();
+    await createRoute(route);
+    await deleteRoute(route.id);
+    const routes = await listRoutes();
+    expect(routes.find((r) => r.id === route.id)).toBeUndefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const r = resolve(dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": r,
+    },
+  },
   test: {
     environment: "node",
     include: [
@@ -9,18 +18,13 @@ export default defineConfig({
       "lib/**/*.test.ts",
       "schemas/**/*.test.ts",
     ],
-  exclude: ["e2e/**", "**/*.spec.ts", "node_modules/**", "**/dist/**"],
+    exclude: ["e2e/**", "**/*.spec.ts", "node_modules/**", "**/dist/**"],
     globals: true,
     setupFiles: [],
     coverage: {
       reporter: ["text", "html"],
       include: ["features/**/utils/**/*.ts", "schemas/**/*.ts"],
-      exclude: [
-        "**/*.test.ts",
-        "app/**",
-        "components/**",
-        "features/**/workers/**",
-      ],
+      exclude: ["**/*.test.ts", "app/**", "components/**", "features/**/workers/**"],
       thresholds: {
         lines: 0.7,
         functions: 0.7,


### PR DESCRIPTION
## Summary
- prefer Prisma for route persistence in production, falling back to in-memory store locally
- add `RouteList` component with optimistic create/delete UX
- cover route actions with unit tests and configure Vitest path alias

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, missing deps, and unused vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff4b2d2c8327b134d2e70723ee92