### PR TITLE
feat: add step playback and enhanced practice metrics

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ import Metronome from "../components/metronome"
 import RouteManager from "../components/route-manager"
 import RouteViewer from "@/features/routes/RouteViewer"
 import PracticeHUD from "@/features/practice/PracticeHUD"
+import StepPlayback from "@/features/practice/StepPlayback"
 import MusicUpload from "@/features/practice/MusicUpload"
 import PhrasingSuggest from "@/features/practice/PhrasingSuggest"
 import StudentTracker from "../components/student-tracker"
@@ -268,17 +269,24 @@ export default function MarchingBandApp() {
                     </div>
                   </div>
                   <div className="mt-4">
-                    <PracticeHUD
-                      bpm={bpm}
-                      stepSizeYards={stepSizeYards}
-                      current={students.find((s) => s.id === currentStudentId)?.position || null}
-                      route={currentRoute}
-                      previewIndex={previewIndex}
-                    />
-                  </div>
-                  <div className="mt-4">
-                    <RouteViewer route={currentRoute} value={previewIndex} onChange={setPreviewIndex} />
-                  </div>
+                  <PracticeHUD
+                    bpm={bpm}
+                    stepSizeYards={stepSizeYards}
+                    current={students.find((s) => s.id === currentStudentId)?.position || null}
+                    route={currentRoute}
+                    previewIndex={previewIndex}
+                  />
+                </div>
+                <div className="mt-4 flex items-center justify-between gap-4">
+                  <StepPlayback
+                    route={currentRoute}
+                    index={previewIndex}
+                    onIndexChange={setPreviewIndex}
+                    bpm={bpm}
+                    audioContext={audioContext}
+                  />
+                  <RouteViewer route={currentRoute} value={previewIndex} onChange={setPreviewIndex} />
+                </div>
                 </CardContent>
               </Card>
             </TabsContent>
@@ -393,7 +401,14 @@ export default function MarchingBandApp() {
                     previewIndex={previewIndex}
                   />
                 </div>
-                <div className="mt-4">
+                <div className="mt-4 flex items-center justify-between gap-4">
+                  <StepPlayback
+                    route={currentRoute}
+                    index={previewIndex}
+                    onIndexChange={setPreviewIndex}
+                    bpm={bpm}
+                    audioContext={audioContext}
+                  />
                   <RouteViewer route={currentRoute} value={previewIndex} onChange={setPreviewIndex} />
                 </div>
               </CardContent>

--- a/features/practice/PracticeHUD.tsx
+++ b/features/practice/PracticeHUD.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { distanceYards, directionVector, yardsToSteps } from "@/features/practice/utils/errorMetrics"
+import { distanceYards, directionVector, yardsToSteps, errorComponentsYards, errorComponentsSteps } from "@/features/practice/utils/errorMetrics"
 
 export default function PracticeHUD({
   bpm,
@@ -25,7 +25,9 @@ export default function PracticeHUD({
     const distYards = distanceYards(current, target)
     const distSteps = yardsToSteps(distYards, stepSizeYards)
     const dir = directionVector(current, target)
-    return { distYards, distSteps, dir }
+    const compsY = errorComponentsYards(current, target)
+    const compsS = errorComponentsSteps(current, target, stepSizeYards)
+    return { distYards, distSteps, dir, compsY, compsS }
   }, [current, target, stepSizeYards])
 
   return (
@@ -40,7 +42,10 @@ export default function PracticeHUD({
           {metrics ? (
             <span>
               {metrics.distYards.toFixed(1)} yd ({metrics.distSteps.toFixed(1)} steps)
-              <span className="ml-2 text-muted-foreground">→ dx {(metrics.dir.x).toFixed(2)}, dy {(metrics.dir.y).toFixed(2)}</span>
+              <span className="ml-2 text-muted-foreground">
+                lat {metrics.compsY.lateralYards.toFixed(1)}y ({metrics.compsS.lateralSteps.toFixed(1)}st), long {metrics.compsY.longitudinalYards.toFixed(1)}y ({metrics.compsS.longitudinalSteps.toFixed(1)}st)
+              </span>
+              <span className="ml-2 text-muted-foreground">→ dx {metrics.dir.x.toFixed(2)}, dy {metrics.dir.y.toFixed(2)}</span>
             </span>
           ) : (
             <span className="text-muted-foreground">No target</span>

--- a/features/practice/PracticeHUD.tsx
+++ b/features/practice/PracticeHUD.tsx
@@ -43,7 +43,7 @@ export default function PracticeHUD({
             <span>
               {metrics.distYards.toFixed(1)} yd ({metrics.distSteps.toFixed(1)} steps)
               <span className="ml-2 text-muted-foreground">
-                lat {metrics.compsY.lateralYards.toFixed(1)}y ({metrics.compsS.lateralSteps.toFixed(1)}st), long {metrics.compsY.longitudinalYards.toFixed(1)}y ({metrics.compsS.longitudinalSteps.toFixed(1)}st)
+                Lateral {metrics.compsY.lateralYards.toFixed(1)} yards ({metrics.compsS.lateralSteps.toFixed(1)} steps), Longitudinal {metrics.compsY.longitudinalYards.toFixed(1)} yards ({metrics.compsS.longitudinalSteps.toFixed(1)} steps)
               </span>
               <span className="ml-2 text-muted-foreground">→ dx {metrics.dir.x.toFixed(2)}, dy {metrics.dir.y.toFixed(2)}</span>
             </span>

--- a/features/practice/StepPlayback.tsx
+++ b/features/practice/StepPlayback.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { useEffect, useRef, useState, useTransition, useCallback } from "react"
+import { Button } from "@/components/ui/button"
+import { Play, Pause } from "lucide-react"
+import type { MarchingRoute } from "@/schemas/routeSchema"
+
+interface StepPlaybackProps {
+  route: MarchingRoute | null
+  index: number
+  onIndexChange: (index: number) => void
+  bpm: number
+  audioContext: AudioContext | null
+}
+
+export default function StepPlayback({ route, index, onIndexChange, bpm, audioContext }: StepPlaybackProps) {
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const timerRef = useRef<number | null>(null)
+
+  const playClick = useCallback(() => {
+    if (!audioContext) return
+    const osc = audioContext.createOscillator()
+    const gain = audioContext.createGain()
+    osc.type = "sine"
+    osc.frequency.setValueAtTime(880, audioContext.currentTime)
+    gain.gain.setValueAtTime(0, audioContext.currentTime)
+    gain.gain.linearRampToValueAtTime(0.25, audioContext.currentTime + 0.01)
+    gain.gain.linearRampToValueAtTime(0, audioContext.currentTime + 0.1)
+    osc.connect(gain)
+    gain.connect(audioContext.destination)
+    osc.start()
+    osc.stop(audioContext.currentTime + 0.1)
+  }, [audioContext])
+
+  useEffect(() => {
+    if (!isPlaying) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      return
+    }
+    const spb = 60 / Math.max(1, bpm)
+    timerRef.current = window.setTimeout(() => {
+      if (!route || route.waypoints.length === 0) {
+        setIsPlaying(false)
+        return
+      }
+      const next = index + 1
+      if (next >= route.waypoints.length) {
+        setIsPlaying(false)
+        return
+      }
+      startTransition(() => onIndexChange(next))
+      playClick()
+    }, spb * 1000)
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [isPlaying, bpm, index, route, startTransition, onIndexChange, playClick])
+
+  const handleStart = () => {
+    if (!route || route.waypoints.length === 0) return
+    if (audioContext && audioContext.state === "suspended") {
+      audioContext.resume().catch(() => {})
+    }
+    setIsPlaying(true)
+    playClick()
+  }
+
+  const handleStop = () => {
+    setIsPlaying(false)
+  }
+
+  useEffect(() => {
+    if (!route) {
+      setIsPlaying(false)
+    }
+  }, [route])
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button onClick={isPlaying ? handleStop : handleStart} size="sm" variant="outline" disabled={!route}>
+        {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+      </Button>
+      <span className="text-xs text-muted-foreground" aria-live="polite">
+        {isPending ? "…" : isPlaying ? "Playing" : "Stopped"}
+      </span>
+    </div>
+  )
+}
+

--- a/features/practice/StepPlayback.tsx
+++ b/features/practice/StepPlayback.tsx
@@ -66,7 +66,9 @@ export default function StepPlayback({ route, index, onIndexChange, bpm, audioCo
   const handleStart = () => {
     if (!route || route.waypoints.length === 0) return
     if (audioContext && audioContext.state === "suspended") {
-      audioContext.resume().catch(() => {})
+      audioContext.resume().catch((err) => {
+        console.error("Failed to resume AudioContext:", err);
+      });
     }
     setIsPlaying(true)
     playClick()

--- a/features/practice/index.ts
+++ b/features/practice/index.ts
@@ -2,5 +2,6 @@ export { default as SettingsPanel } from "./SettingsPanel";
 export { default as PracticeHUD } from "./PracticeHUD";
 export { default as MusicUpload } from "./MusicUpload";
 export { default as PhrasingSuggest } from "./PhrasingSuggest";
+export { default as StepPlayback } from "./StepPlayback";
 export {};
 

--- a/features/practice/utils/errorMetrics.test.ts
+++ b/features/practice/utils/errorMetrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { yardsToSteps, stepsToYards, distanceYards, errorComponentsYards, errorInSteps, isOffTarget } from "./errorMetrics"
+import { yardsToSteps, stepsToYards, distanceYards, errorComponentsYards, errorInSteps, isOffTarget, errorComponentsSteps } from "./errorMetrics"
 
 describe("errorMetrics", () => {
   it("converts yards to steps and back", () => {
@@ -22,6 +22,9 @@ describe("errorMetrics", () => {
     const { yards, steps } = errorInSteps(current, target, 0.75)
     expect(yards).toBeCloseTo(Math.hypot(1, 2))
     expect(steps).toBeCloseTo(yards / 0.75)
+    const compsSteps = errorComponentsSteps(current, target, 0.75)
+    expect(compsSteps.longitudinalSteps).toBeCloseTo(comps.longitudinalYards / 0.75)
+    expect(compsSteps.lateralSteps).toBeCloseTo(comps.lateralYards / 0.75)
   })
 
   it("checks off-target threshold", () => {

--- a/features/practice/utils/errorMetrics.ts
+++ b/features/practice/utils/errorMetrics.ts
@@ -39,6 +39,14 @@ export function errorInSteps(current: Vec2, target: Vec2, stepSizeYards: number)
   return { yards: dist, steps }
 }
 
+export function errorComponentsSteps(current: Vec2, target: Vec2, stepSizeYards: number) {
+  const { lateralYards, longitudinalYards } = errorComponentsYards(current, target)
+  return {
+    lateralSteps: yardsToSteps(lateralYards, stepSizeYards),
+    longitudinalSteps: yardsToSteps(longitudinalYards, stepSizeYards),
+  }
+}
+
 export function isOffTarget(current: Vec2, target: Vec2, stepSizeYards: number, thresholdSteps = 0.5) {
   const { steps } = errorInSteps(current, target, stepSizeYards)
   return steps > thresholdSteps


### PR DESCRIPTION
## Summary
- add StepPlayback component for audible step-by-step route playback
- surface lateral/longitudinal error metrics in PracticeHUD
- expose step error helpers for conversions

## Testing
- `npm test`
- `npx eslint app/page.tsx features/practice/PracticeHUD.tsx features/practice/StepPlayback.tsx features/practice/utils/errorMetrics.ts features/practice/utils/errorMetrics.test.ts` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff56d9648327aa129d22574a27ab