### PR TITLE
feat(auth): add show and part preferences

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,17 +1,19 @@
 import { redirect } from "next/navigation"
 import { currentUser } from "@clerk/nextjs/server"
 import SettingsPanel from "@/features/practice/SettingsPanel"
+import { getShows } from "@/lib/fetchers/shows"
 
 export default async function SettingsPage() {
   const user = await currentUser()
   if (!user) redirect("/sign-in")
+  const shows = await getShows()
 
   return (
     <div className="max-w-3xl mx-auto p-6">
       <h1 className="text-2xl font-semibold mb-4">Settings</h1>
       <p className="text-gray-600">User: {user.emailAddresses?.[0]?.emailAddress ?? user.id}</p>
       <div className="mt-6">
-        <SettingsPanel />
+        <SettingsPanel shows={shows} />
       </div>
     </div>
   )

--- a/features/practice/SettingsPanel.tsx
+++ b/features/practice/SettingsPanel.tsx
@@ -1,34 +1,56 @@
 "use client"
 import { useActionState, useEffect, useState } from "react"
-import { savePreferences } from "@/lib/actions/preferences"
+import { savePreferences, getPreferences } from "@/lib/actions/preferences"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
+import type { Show } from "@/schemas"
 
 type FieldType = "high-school" | "college"
 type Notation = "yardline" | "steps-off"
 
-export default function SettingsPanel() {
+interface Props {
+  shows: Show[]
+}
+
+export default function SettingsPanel({ shows }: Props) {
   const [step, setStep] = useState(0.75)
   const [fieldType, setFieldType] = useState<FieldType>("high-school")
   const [notationStyle, setNotationStyle] = useState<Notation>("yardline")
+  const [showId, setShowId] = useState<string>(shows[0]?.id ?? "")
+  const [partId, setPartId] = useState<string>(shows[0]?.parts[0]?.id ?? "")
   const [savedAt, setSavedAt] = useState<number | null>(null)
 
   const action = async () => {
     // directly call server action
-    await savePreferences({ stepSizeYards: step, fieldType, notationStyle })
+    await savePreferences({ stepSizeYards: step, fieldType, notationStyle, showId, partId })
     return { ok: true }
   }
   const [state, formAction, pending] = useActionState(action, { ok: false })
 
   useEffect(() => {
     if (state.ok) {
-  // transient inline success indicator
-  setSavedAt(Date.now())
-  const t = setTimeout(() => setSavedAt(null), 2500)
-  return () => clearTimeout(t)
+      setSavedAt(Date.now())
+      const t = setTimeout(() => setSavedAt(null), 2500)
+      return () => clearTimeout(t)
     }
   }, [state])
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const pref = await getPreferences()
+        if (pref) {
+          if (typeof pref.stepSizeYards === "number") setStep(pref.stepSizeYards)
+          if (pref.fieldType === "high-school" || pref.fieldType === "college") setFieldType(pref.fieldType as FieldType)
+          if (pref.notationStyle === "yardline" || pref.notationStyle === "steps-off")
+            setNotationStyle(pref.notationStyle as Notation)
+          if (pref.showId) setShowId(pref.showId)
+          if (pref.partId) setPartId(pref.partId)
+        }
+      } catch {}
+    })()
+  }, [shows])
 
   return (
     <form action={formAction} className="space-y-4">
@@ -48,6 +70,42 @@ export default function SettingsPanel() {
   <select id="notation" className="border rounded p-2" value={notationStyle} onChange={(e) => setNotationStyle(e.target.value as Notation)}>
           <option value="yardline">Yardline</option>
           <option value="steps-off">Steps off</option>
+        </select>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="show">Show</Label>
+        <select
+          id="show"
+          className="border rounded p-2"
+          value={showId}
+          onChange={(e) => {
+            const id = e.target.value
+            setShowId(id)
+            const firstPart = shows.find((s) => s.id === id)?.parts[0]?.id ?? ""
+            setPartId(firstPart)
+          }}
+        >
+          {shows.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="part">Part</Label>
+        <select
+          id="part"
+          className="border rounded p-2"
+          value={partId}
+          onChange={(e) => setPartId(e.target.value)}
+        >
+          {shows
+            .find((s) => s.id === showId)?.parts.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            )) ?? null}
         </select>
       </div>
       <div className="flex items-center gap-3">

--- a/lib/actions/preferences.ts
+++ b/lib/actions/preferences.ts
@@ -7,6 +7,8 @@ const PrefSchema = z.object({
   stepSizeYards: z.number().positive().max(5),
   fieldType: z.enum(["high-school", "college"]),
   notationStyle: z.enum(["yardline", "steps-off"]),
+  showId: z.string().optional(),
+  partId: z.string().optional(),
 })
 
 export async function getPreferences() {

--- a/lib/fetchers/shows.ts
+++ b/lib/fetchers/shows.ts
@@ -1,0 +1,8 @@
+import "server-only"
+import { prisma } from "@/lib/db"
+import { ShowSchema, type Show } from "@/schemas"
+
+export async function getShows(): Promise<Show[]> {
+  const shows = await prisma.show.findMany({ include: { parts: true } })
+  return ShowSchema.array().parse(shows)
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,25 @@ model UserPreferences {
   stepSizeYards  Float    @default(0.75)
   fieldType      String   @default("high-school")
   notationStyle  String   @default("yardline")
+  showId         String?
+  partId         String?
   userId         String   @unique
   user           User     @relation(fields: [userId], references: [id])
+}
+
+model Show {
+  id        String @id @default(cuid())
+  name      String
+  parts     Part[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Part {
+  id        String @id @default(cuid())
+  name      String
+  showId    String
+  show      Show   @relation(fields: [showId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -1,4 +1,5 @@
 export * from "./musicSchema";
 export * from "./routeSchema";
 export * from "./userPreferencesSchema";
+export * from "./showSchema";
 

--- a/schemas/schemas.test.ts
+++ b/schemas/schemas.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import { RouteSchema, WaypointSchema } from "./routeSchema"
 import { UserPreferencesSchema } from "./userPreferencesSchema"
 import { ParsedMusicSchema } from "./musicSchema"
+import { ShowSchema, PartSchema } from "./showSchema"
 
 describe("Route & Waypoint schemas", () => {
   it("parses a valid route", () => {
@@ -35,6 +36,12 @@ describe("UserPreferences schema", () => {
   it("rejects non-positive step size", () => {
     expect(() => UserPreferencesSchema.parse({ stepSizeYards: 0 })).toThrow()
   })
+
+  it("accepts optional show and part IDs", () => {
+    const prefs = UserPreferencesSchema.parse({ stepSizeYards: 0.75, showId: "s1", partId: "p1" })
+    expect(prefs.showId).toBe("s1")
+    expect(prefs.partId).toBe("p1")
+  })
 })
 
 describe("ParsedMusic schema", () => {
@@ -50,5 +57,16 @@ describe("ParsedMusic schema", () => {
 
   it("rejects invalid time signature", () => {
     expect(() => ParsedMusicSchema.parse({ tempo: 120, timeSignature: { beats: 0, beatValue: 4 }, measures: [] })).toThrow()
+  })
+})
+
+describe("Show and Part schemas", () => {
+  it("parses a show with parts", () => {
+    const show = ShowSchema.parse({ id: "s1", name: "Halftime", parts: [{ id: "p1", name: "Trumpet" }] })
+    expect(show.parts[0].name).toBe("Trumpet")
+  })
+
+  it("rejects part without name", () => {
+    expect(() => PartSchema.parse({ id: "p1" })).toThrow()
   })
 })

--- a/schemas/showSchema.ts
+++ b/schemas/showSchema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod"
+
+export const PartSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+})
+
+export const ShowSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  parts: z.array(PartSchema).default([]),
+})
+
+export type Part = z.infer<typeof PartSchema>
+export type Show = z.infer<typeof ShowSchema>

--- a/schemas/userPreferencesSchema.ts
+++ b/schemas/userPreferencesSchema.ts
@@ -5,6 +5,8 @@ export const UserPreferencesSchema = z.object({
   stepSizeYards: z.number().positive().default(2.5),
   fieldType: z.enum(["high-school", "college"]).default("high-school"),
   notationStyle: z.enum(["yardline", "steps-off"]).default("yardline"),
+  showId: z.string().optional(),
+  partId: z.string().optional(),
 });
 
 export type UserPreferences = z.infer<typeof UserPreferencesSchema>;


### PR DESCRIPTION
## Summary
- add show and part schemas with new fetcher
- extend user preferences and prisma model for showId/partId
- surface show/part selection in settings panel

## Testing
- `npm run lint` *(fails: Unexpected any in use-audio-context.ts, utils.test.ts)*
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdff6c97248327a8c0cebb973d7786