### PR TITLE
ci: add workflows for lint, typecheck, tests and Playwright smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        command: [lint, typecheck, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run ${{ matrix.command }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,23 @@
+name: Playwright Smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run e2e -- e2e/smoke.spec.ts

--- a/hooks/use-audio-context.ts
+++ b/hooks/use-audio-context.ts
@@ -9,7 +9,12 @@ export function useAudioContext() {
   useEffect(() => {
     const initAudioContext = async () => {
       try {
-        const context = new (window.AudioContext || (window as any).webkitAudioContext)()
+        const context = new (
+          window.AudioContext ||
+          (window as typeof window & {
+            webkitAudioContext: typeof AudioContext
+          }).webkitAudioContext
+        )()
 
         // Resume context if suspended (required by some browsers)
         if (context.state === "suspended") {

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -3,7 +3,7 @@ import { cn } from "./utils";
 
 describe("cn utility", () => {
   it("merges class names and resolves conflicts", () => {
-    const result = cn("p-2", "p-4", false && "hidden", null as any, undefined as any, "text-white");
+    const result = cn("p-2", "p-4", false && "hidden", null, undefined, "text-white");
     expect(result).toContain("p-4");
     expect(result).toContain("text-white");
     expect(result).not.toContain("hidden");


### PR DESCRIPTION
## Summary
- add CI workflow running lint, typecheck, and unit tests
- add Playwright smoke workflow
- fix lint errors in audio and util tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npx playwright test e2e/smoke.spec.ts` *(fails: Publishable key not valid)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff74b150832789c0cd078dad0437