### PR TITLE
Resolve lint warnings in audio and GPS utilities

### DIFF
--- a/features/gps/hooks/useGpsTracker.ts
+++ b/features/gps/hooks/useGpsTracker.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { gpsStore } from "@/lib/gps/store";
 
 interface GPSTrackingState {
@@ -58,10 +58,10 @@ export function useGpsTracker(opts: UseGpsOptions = {}) {
         );
       });
       return true;
-    } catch (e) {
-      setState((p) => ({ ...p, error: "Failed to request location permission" }));
-      return false;
-    }
+      } catch {
+        setState((p) => ({ ...p, error: "Failed to request location permission" }));
+        return false;
+      }
   }, []);
 
   const startTracking = useCallback(() => {

--- a/features/gps/utils/kalmanFilter.ts
+++ b/features/gps/utils/kalmanFilter.ts
@@ -48,9 +48,7 @@ export function createKalman2D(options: Partial<Kalman2DOptions> = {}) {
 
     // x = F * x
     const x = state.x;
-    const nx0 = F[0] * x[0] + F[2] * x[2];
-    const nx1 = F[5 - 4] * x[1] + F[7 - 4] * x[3]; // F[1,1]=1; F[1,3]=dt
-    // Clarify indices: we'll compute manually
+    // Clarify indices: compute next state manually for performance
     const nx_lat = x[0] + dt * x[2];
     const nx_lon = x[1] + dt * x[3];
     const nv_lat = x[2];

--- a/hooks/use-audio-context.ts
+++ b/hooks/use-audio-context.ts
@@ -9,7 +9,11 @@ export function useAudioContext() {
   useEffect(() => {
     const initAudioContext = async () => {
       try {
-        const context = new (window.AudioContext || (window as any).webkitAudioContext)()
+        const Ctor =
+          window.AudioContext ||
+          (window as Window & { webkitAudioContext: typeof AudioContext })
+            .webkitAudioContext
+        const context = new Ctor()
 
         // Resume context if suspended (required by some browsers)
         if (context.state === "suspended") {
@@ -37,12 +41,14 @@ export function useAudioContext() {
     return () => {
       document.removeEventListener("click", handleUserInteraction)
       document.removeEventListener("touchstart", handleUserInteraction)
-
-      if (audioContext) {
-        audioContext.close()
-      }
     }
   }, [])
+
+  useEffect(() => {
+    return () => {
+      audioContext?.close()
+    }
+  }, [audioContext])
 
   return { audioContext, isAudioReady }
 }

--- a/hooks/use-audio-context.ts
+++ b/hooks/use-audio-context.ts
@@ -44,14 +44,10 @@ export function useAudioContext() {
       if (audioContext) {
         void audioContext.close()
       }
+      if (audioContext) {
+        audioContext.close()
+      }
     }
   }, [])
-
-  useEffect(() => {
-    return () => {
-      audioContext?.close()
-    }
-  }, [audioContext])
-
   return { audioContext, isAudioReady }
 }

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import { cn } from "./utils";
 
 describe("cn utility", () => {
-  it("merges class names and resolves conflicts", () => {
-    const result = cn("p-2", "p-4", false && "hidden", null as any, undefined as any, "text-white");
+    it("merges class names and resolves conflicts", () => {
+      const result = cn("p-2", "p-4", false && "hidden", null, undefined, "text-white");
     expect(result).toContain("p-4");
     expect(result).toContain("text-white");
     expect(result).not.toContain("hidden");

--- a/public/sw.js
+++ b/public/sw.js
@@ -73,7 +73,7 @@ self.addEventListener('fetch', (event) => {
         const cache = await caches.open(RUNTIME_CACHE);
         cache.put(request, response.clone());
         return response;
-      } catch (err) {
+        } catch {
         const cache = await caches.open(STATIC_CACHE);
         const cached = await caches.match(request);
         return cached || (await cache.match(OFFLINE_URL));
@@ -104,13 +104,13 @@ self.addEventListener('fetch', (event) => {
       const cache = await caches.open(IMG_CACHE);
       const cached = await cache.match(request);
       if (cached) return cached;
-      try {
-        const resp = await fetch(request);
-        cache.put(request, resp.clone());
-        return resp;
-      } catch (err) {
-        return caches.match('/vercel.svg');
-      }
+        try {
+          const resp = await fetch(request);
+          cache.put(request, resp.clone());
+          return resp;
+        } catch {
+          return caches.match('/vercel.svg');
+        }
     })());
     return;
   }


### PR DESCRIPTION
## Summary
- remove unused variables in Kalman filter utility
- clean up audio context hook with proper typing and dependency handling
- tidy GPS tracker hook, service worker, and util tests to avoid `any` and unused vars

## Testing
- `npx eslint features/gps/utils/kalmanFilter.ts hooks/use-audio-context.ts lib/utils.test.ts public/sw.js features/gps/hooks/useGpsTracker.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be03a84d4883279a52e111fb0cd535